### PR TITLE
fix: 开发环境需要 Windows 11 SDK

### DIFF
--- a/src/dev/get-started/devlopment.md
+++ b/src/dev/get-started/devlopment.md
@@ -10,6 +10,7 @@
 
 - [.NET 8.0 SDK](https://dotnet.microsoft.com/zh-cn/download/dotnet/8.0)
 - [Visual Studio 2022](https://visualstudio.microsoft.com/)，包括【.NET 桌面开发】工作负载
+- [适用于 Windows 11 的 Windows SDK](https://developer.microsoft.com/zh-cn/windows/downloads/windows-sdk/)，版本10.0.26100
 - [Git](https://git-scm.com/)
 - [Powershell Core](https://github.com/PowerShell/PowerShell)
 


### PR DESCRIPTION
ClassIsland 2 的本地编译似乎需要 Windows 11 SDK
不然好像会有一个 Reference 模块报错

> 我不确定插件环境和程序本体环境是不是都要，所以开了两个PR