### PR TITLE
更新开发环境时路径错误

### DIFF
--- a/src/dev/get-started/development-plugins.md
+++ b/src/dev/get-started/development-plugins.md
@@ -84,6 +84,7 @@ git checkout 1.5.0.2
 ``` shell
 git pull
 git submodule update --init --recursive
+cd ../
 ./tools/plugin/build.ps1
 ```
 


### PR DESCRIPTION
更新时应在运行build.ps1时返回到ClassIsland，否则执行`git submodule update --init --recursive`目录会留在ClassIsland.Desktop，找不到build.ps1
更新：
在git submodule update --init --recursive后加入`../`